### PR TITLE
fix handlepushnotification on Android - haven't attempted iOS

### DIFF
--- a/android/src/main/java/com/voximplant/reactnative/VoxImplantModule.java
+++ b/android/src/main/java/com/voximplant/reactnative/VoxImplantModule.java
@@ -217,7 +217,10 @@ public class VoxImplantModule extends ReactContextBaseJavaModule implements VoxI
 
     @ReactMethod
     public void handlePushNotification(ReadableMap notification) {
-        this.client.handlePushNotification(this.createHashMap(notification));
+        Map<String, String> map = new HashMap<>();
+        String key = "voximplant";
+        map.put(key, notification.getString(key));
+        this.client.handlePushNotification(map);
     }
 
     // VoxImplantCallback implementation


### PR DESCRIPTION
`handlePushNotification` should only send a map of voximplant key and value to the client. 
There are other values in the map (like fcm's) which are non-string values and `createHashMap` fails on that.